### PR TITLE
Change HTTP status code for current doc redirections.

### DIFF
--- a/src/rocqproverorg_web/lib/middleware.ml
+++ b/src/rocqproverorg_web/lib/middleware.ml
@@ -43,7 +43,7 @@ let language_manual_version next_handler request =
     | u -> u
   in
   if init_path = path then next_handler request
-  else Dream.redirect request (String.concat "/" path)
+  else Dream.redirect ~status:`Found request (String.concat "/" path)
 
 let head handler request =
   match Dream.method_ request with


### PR DESCRIPTION
The goal is that search engines will pick up URLs that redirect to the current version of the doc instead of only remembering their targets.

May be enough to fix #80.