### PR TITLE
Link to signed macos installer for 2025.01.0

### DIFF
--- a/data/releases/2025.01.0.md
+++ b/data/releases/2025.01.0.md
@@ -18,12 +18,9 @@ highlights: |
 ### Recommended binary installers
 
 - [Windows (64 bit) installer for Coq 8.20](https://github.com/coq/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-Windows-x86_64.exe)
-- [MacOS (arm) installer for Coq 8.20](https://github.com/coq/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-MacOS-arm64-UNSIGNED.dmg)
+- [MacOS (arm) installer for Coq 8.20](https://github.com/rocq-prover/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-MacOS-arm64.dmg)
 
-**Note**: the MacOS intel installer is work in progress, and the arm installer is not yet signed.
-  The unsigned Mac installers are hard to use, especially when a signed version has been installed before. 
-  In case you need this urgently (e.g. for a lecture) we can supply a script which signs it locally after installation (such a signature is only valid on the machine it was made on as far as we can tell). 
-  The previous [MacOS (arm) installer for Coq 8.19.2](https://github.com/coq/platform/releases/download/2024.10.0/Coq-Platform-release-2024.10.0-version.8.19.2024.10-MacOS-arm64.dmg) is signed.
+**Note**: the MacOS intel installer is work in progress.
 
 **Note**: snap is no longer supported (we are working on a replacement)
 

--- a/data/releases/2025.01.0.md
+++ b/data/releases/2025.01.0.md
@@ -17,10 +17,9 @@ highlights: |
 
 ### Recommended binary installers
 
-- [Windows (64 bit) installer for Coq 8.20](https://github.com/coq/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-Windows-x86_64.exe)
+- [Windows (64 bit) installer for Coq 8.20](https://github.com/rocq-prover/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-Windows-x86_64.exe)
 - [MacOS (arm) installer for Coq 8.20](https://github.com/rocq-prover/platform/releases/download/2025.01.0/Coq-Platform-release-2025.01.0-version.8.20.2025.01-MacOS-arm64.dmg)
 
-**Note**: the MacOS intel installer is work in progress.
 
 **Note**: snap is no longer supported (we are working on a replacement)
 


### PR DESCRIPTION
Update the signed MacOS installer URL and remove cautionary tale about unsigned installers