### PR TITLE
Roadmap discoverability

### DIFF
--- a/src/rocqproverorg_frontend/pages/about.eml
+++ b/src/rocqproverorg_frontend/pages/about.eml
@@ -44,6 +44,15 @@ Layout.render
             <div class="font-semibold text-lg text-content dark:text-dark-content">Awards</div>
           </a>
         </div>
+        <div>
+          <a
+            class="hover:text-primary dark:hover:text-dark-primary hover:bg-primary_25 dark:hover:bg-dark-primary_20 h-28 w-28 rounded-lg inline-block transition-colors"
+            href="/roadmap"
+          >
+            <%s! Icons.star "h-10 w-10 mb-4 m-auto mt-6" %>
+            <div class="font-semibold text-lg text-content dark:text-dark-content">Future</div>
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/src/rocqproverorg_frontend/pages/why.eml
+++ b/src/rocqproverorg_frontend/pages/why.eml
@@ -175,11 +175,7 @@ Layout.render
               </p>
             </li>
           </ul>
-        </div>
-        <h2 id="features">Future</h2>
-        <div class="space-y-10">
-          See our <a href="/roadmap">roadmap</a> for upcoming developments improving the Rocq Prover and Platform.
-        </div>
+        </div>        
       </div>
       <div class="prose dark:prose-invert lg:prose-lg mx-auto max-w-5xl">
         <h4 class="pt-12 pb-4">Bibliography</h4> <!-- FIXME -->


### PR DESCRIPTION
Fixes #53 by moving the roadmap link to a "future" icon in About Rocq.