### PR TITLE
Remove misleading "open-source" mention on the packages page

### DIFF
--- a/src/rocqproverorg_frontend/pages/packages.eml
+++ b/src/rocqproverorg_frontend/pages/packages.eml
@@ -20,7 +20,7 @@ in
             <div class="border-b border-card_border dark:border-dark-separator_30 pb-8 md:pb-0 md:border-none md:flex-grow">
                 <h1 class="text-title dark:text-dark-title text-2xl md:text-5xl tracking-wider">Rocq Packages</h1>
                 <p class="text-content dark:text-dark-content text-lg my-4 md:my-6 max-w-md">
-                Explore hundreds of open-source Rocq packages with their documentation
+                Explore hundreds of Rocq packages with their documentation
                 </p>
                 <div
                         class="flex flex-col lg:flex-row lg:space-x-6 space-y-5 lg:space-y-0 md:space-y-5 w-full lg:w-auto mt-8">


### PR DESCRIPTION
Fixes #163 