### PR TITLE
Fix links for Ltac2 matching terms and goals

### DIFF
--- a/data/tutorials/platform/6_01_ltac2.md
+++ b/data/tutorials/platform/6_01_ltac2.md
@@ -36,8 +36,8 @@ In particular, it features:
 
 - <a href="https://github.com/rocq-prover/platform-docs/issues/93" style="color:red">Quoting in Ltac2</a>
 - Matching Terms and Goals in Ltac2
-  [interactive version](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_backtracking.html) and
-  [source code](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_backtracking.v)
+  [interactive version](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_matching_terms_and_goals.html) and
+  [source code](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_matching_terms_and_goals.v)
 - Backtracking in Ltac2
   [interactive version](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_backtracking.html) and
   [source code](https://rocq-prover.org/platform-docs/metaprogramming/ltac2/tutorial_backtracking.v)


### PR DESCRIPTION
Found a broken link in the Ltac2 docs