### PR TITLE
Add support for emeritus members on Rocq team pages

### DIFF
--- a/data/governance.yml
+++ b/data/governance.yml
@@ -16,6 +16,54 @@ teams:
   - name: Matthieu Sozeau
     github: mattam82
     role: Project Leader
+  - name: Yves Bertot
+    github: ybertot
+    emeritus: true
+  - name: Emilio Jesús Gallego Arias
+    github: ejgallego
+    emeritus: true
+  - name: Maxime Dénès
+    github: maximedenes
+    emeritus: true
+  - name: Pierre Letouzey
+    github: letouzey
+    emeritus: true
+  - name: Vincent Laporte
+    github: vbgl
+    emeritus: true
+  - name: Arnaud Spiwack
+    github: aspiwack
+    emeritus: true
+  - name: Bruno Barras
+    github: barras
+    emeritus: true
+  - name: Jean-Christophe Filliâtre
+    github: backtracking
+    emeritus: true
+  - name: David Delahaye
+    github: delahayd
+    emeritus: true
+  - name: Benjamin Monate
+    github: monate
+    emeritus: true
+  - name: Chetan R. Murthy
+    github: chetmurthy
+    emeritus: true
+  - name: Thierry Coquand
+    emeritus: true
+    role: Creator (1984), V1-V5
+  - name: Gérard Huet
+    emeritus: true
+    role: Creator and Head of the Project (1984-1995), V1-V5
+  - name: Christine Paulin-Mohring
+    emeritus: true
+    role: V4.4-V8, Head of the Project (1995-2006)
+  - name: Gilles Dowek
+    emeritus: true
+  - name: Eduardo Giménez
+    emeritus: true
+  - name: Benjamin Werner
+    emeritus: true
 - id: community
   name: Community
   description: The Community team is responsible for managing forums, social media, and community events.

--- a/data/governance.yml
+++ b/data/governance.yml
@@ -255,7 +255,8 @@ teams:
       github: Justme0606
     - name: Erik Martin-Dorel
       github: erikmd
-      role: (emeritus)
+      role: Initial author
+      emeritus: true
 - id: documentation
   name: Documentation
   description: The Documentation team is responsible for the development and maintenance of the Rocq documentation.

--- a/src/rocqproverorg_data/data_intf.ml
+++ b/src/rocqproverorg_data/data_intf.ml
@@ -255,11 +255,21 @@ end
 
 module Governance = struct
   module Member = struct
-    type t = { name : string; github : string; role : string option }
-    [@@deriving of_yaml, show]
+  let key ?github name =
+    match github with
+    | Some github -> github
+    | None -> "name:" ^ String.lowercase_ascii name
 
-    let compare a b = String.compare a.github b.github
-  end
+type t = {
+  name : string;
+  github : string option; [@default None]
+  role : string option;
+  emeritus : bool; [@default false]
+}
+[@@deriving of_yaml, show]
+
+let compare a b = String.compare (key ?github:a.github a.name) (key ?github:b.github b.name)
+end
 
   type contact_kind = GitHub | Email | Discord | Chat [@@deriving show]
 

--- a/src/rocqproverorg_frontend/pages/governance.eml
+++ b/src/rocqproverorg_frontend/pages/governance.eml
@@ -1,7 +1,17 @@
 module MemberSet = Set.Make (Data.Governance.Member)
 
+let active_members members =
+  List.filter (fun (member : Data.Governance.Member.t) -> not member.emeritus) members
+
 let count_members (team : Data.Governance.team) =
-   MemberSet.cardinal (MemberSet.of_list (team.members @ List.concat (List.map (fun (team : Data.Governance.team) -> team.members) team.subteams)))
+   MemberSet.cardinal
+     (MemberSet.of_list
+        (active_members
+           (team.members
+           @ List.concat
+               (List.map
+                  (fun (team : Data.Governance.team) -> team.members)
+                  team.subteams))))
 
 let render_working_group (team : Data.Governance.team) member_label btn_class =
   <div class="flex-col">

--- a/src/rocqproverorg_frontend/pages/governance_team.eml
+++ b/src/rocqproverorg_frontend/pages/governance_team.eml
@@ -4,18 +4,36 @@ let contact_icon (kind : Data.Governance.contact_kind) = match kind with
   | Discord -> Icons.discord
   | Chat -> Icons.chat
 
+let split_members (members : Data.Governance.Member.t list) =
+  List.partition (fun (member : Data.Governance.Member.t) -> not member.emeritus) members
+
+let member_key (member : Data.Governance.Member.t) =
+  Data.Governance.Member.key ?github:member.github member.name
+
 let render_team_member ~default_role (member : Data.Governance.Member.t) =
-  <a href="https://github.com/<%s member.github %>" class="flex gap-x-2 p-4 card dark:dark-card">
-    <img src="https://github.com/<%s member.github %>.png" alt="" class="h-32 w-32 mr-3 inline-block rounded-full">
+  <div class="flex gap-x-2 p-4 card dark:dark-card">
+    <% (match member.github with
+      | Some github -> %>
+    <a href="https://github.com/<%s github %>" class="shrink-0">
+      <img src="https://github.com/<%s github %>.png" alt="" class="h-32 w-32 mr-3 inline-block rounded-full">
+    </a>
+    <% | None -> %>
+    <div class="h-32 w-32 mr-3 inline-flex items-center justify-center rounded-full bg-separator_20 dark:bg-dark-separator_30 text-title dark:text-dark-title text-2xl shrink-0">
+      <%s String.sub member.name 0 1 %>
+    </div>
+    <% ); %>
     <div class="flex flex-col h-full">
       <div class="text-title dark:text-dark-title text-xl mt-3"><%s member.name %></div>
       <div class="text-sm text-content dark:text-dark-content"><%s Option.value ~default:default_role member.role %></div>
+      <% (match member.github with
+        | Some github -> %>
       <div class="mt-auto text-primary dark:text-dark-primary items-center flex gap-1">
         <%s! Icons.github "h-6 w-6" %>
-        <p><%s member.github %></p>
+        <p><%s github %></p>
       </div>
+      <% | None -> () ); %>
     </div>
-  </a>
+  </div>
 
 let render_dev_meeting (dev_meeting : Data.Governance.dev_meeting) _class =
   <div class="gap-4 <%s _class %>">
@@ -48,7 +66,7 @@ let flatten_subteams (team : Data.Governance.team) =
       List.fold_left
         (fun acc member ->
           MemberMap.update
-            (member.Member.github : string)
+            (member_key member)
             (fun m ->
               match m with
               | None -> Some (member, [ subteam.name ])
@@ -56,7 +74,7 @@ let flatten_subteams (team : Data.Governance.team) =
             acc)
         acc subteam.members)
     (team.members
-    |> List.map (fun m -> (m.Member.github, (m, [])))
+    |> List.map (fun m -> (member_key m, (m, [])))
     |> List.to_seq |> MemberMap.of_seq )
     team.subteams
   |> MemberMap.bindings |> List.map snd
@@ -74,6 +92,10 @@ let flatten_subteams (team : Data.Governance.team) =
          })
 
 let render_subteam (team : Data.Governance.team) =
+  let members =
+    if team.subteams = [] then team.members else flatten_subteams team
+  in
+  let active_members, emeritus_members = split_members members in
   <div class="border-b last:border-b-0 border-separator_20 dark:border-dark-separator_30">
     <h3 class="gradient font-semibold text-3xl mb-4 text-title dark:text-dark-title" id="<%s team.name %>"><%s team.name %></h3>
     <p class="text-content dark:text-dark-content my-4"><%s team.description %></p>
@@ -93,14 +115,25 @@ let render_subteam (team : Data.Governance.team) =
       <%s! render_dev_meeting dev_meeting "" %>
     </div>
     <% ); %>
+    <% (match List.length active_members with | 0 -> () | _ -> %>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10 mt-6 mb-4 pb-12">
-      <%s! (if team.subteams = [] then team.members else flatten_subteams team)
+      <%s! active_members
       |> List.map (fun (member : Data.Governance.Member.t) -> render_team_member ~default_role:team.default_role member )
       |> String.concat "\n" %>
     </div>
+    <% ); %>
+    <% (match List.length emeritus_members with | 0 -> () | _ -> %>
+    <h4 class="font-semibold mb-4 text-2xl text-title dark:text-dark-title">Emeritus members</h4>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10 mt-6 mb-4 pb-12">
+      <%s! emeritus_members
+      |> List.map (fun (member : Data.Governance.Member.t) -> render_team_member ~default_role:team.default_role member )
+      |> String.concat "\n" %>
+    </div>
+    <% ); %>
   </div>
 
 let render (t : Data.Governance.team) =
+let active_members, emeritus_members = split_members t.members in
 Layout.render
 ~title:(Printf.sprintf "%s · Rocq Governance" t.name)
 ~description:t.description @@
@@ -141,11 +174,19 @@ Layout.render
       <%s! render_dev_meeting dev_meeting "text-white mb-6" %>
       <% ); %>
 
-      <% (match List.length t.members with | 0 -> () | _ -> %>
+     <% (match List.length active_members with | 0 -> () | _ -> %>
      <div class="">
       <h2 class="font-bold gradient mb-6 mt-6 md:mt-8 text-4xl text-title dark:text-dark-title">People</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12 mb-4">
-        <%s! t.members |> List.map (fun (member : Data.Governance.Member.t) -> render_team_member ~default_role:t.default_role member ) |> String.concat "\n" %>
+       <%s! active_members |> List.map (fun (member : Data.Governance.Member.t) -> render_team_member ~default_role:t.default_role member ) |> String.concat "\n" %>
+      </div>
+     </div>
+      <% ); %>
+     <% (match List.length emeritus_members with | 0 -> () | _ -> %>
+     <div class="">
+      <h2 class="font-bold gradient mb-6 mt-6 md:mt-8 text-4xl text-title dark:text-dark-title">Emeritus members</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12 mb-4">
+       <%s! emeritus_members |> List.map (fun (member : Data.Governance.Member.t) -> render_team_member ~default_role:t.default_role member ) |> String.concat "\n" %>
       </div>
      </div>
       <% ); %>

--- a/tool/ood-gen/lib/governance.ml
+++ b/tool/ood-gen/lib/governance.ml
@@ -9,6 +9,7 @@ type metadata = {
 [@@deriving of_yaml]
 
 let merge_teams (reference : team list) (additions : team list) =
+  let member_key (m : Member.t) = Member.key ?github:m.github m.name in
   (* The team ids are used to determine if a team is already present
    * in the reference list, including as a subteam.
    * If that's the case, we merge the members of the two teams.
@@ -30,7 +31,7 @@ let merge_teams (reference : team list) (additions : team list) =
                      (fun m ->
                        not
                          (List.exists
-                            (fun m' -> m'.github = m.github)
+                            (fun m' -> member_key m' = member_key m)
                             r.members))
                      team.members);
             }


### PR DESCRIPTION
Deployed at https://staging.rocq-prover.org/. See more specifically https://staging.rocq-prover.org/rocq-team/core and https://staging.rocq-prover.org/rocq-team/distribution#Docker.

In the second commit where I imported the emeritus core team members from the Coq team page, my reference was https://web.archive.org/web/20250301080755/coq.inria.fr/coq-team.html.
I did not qualify the roles of everyone because that's too much work (would have to be updated for people who recently became emeritus). If someone (e.g., @mattam82) wants to complete it, feel free to push to this branch, or after merging this PR.